### PR TITLE
Update how the logs are displayed to match hh-plugin

### DIFF
--- a/contracts/MockCoFHE.sol
+++ b/contracts/MockCoFHE.sol
@@ -144,8 +144,8 @@ abstract contract MockCoFHE {
         return truncated;
     }
 
-    string constant LOG_PREFIX = "[MOCK]";
-    string constant LOG_DIVIDER = " | ";
+    string constant LOG_PREFIX = unicode"├ ";
+    string constant LOG_DIVIDER = unicode" | ";
 
     function padRight(
         string memory input,
@@ -170,12 +170,11 @@ abstract contract MockCoFHE {
         string memory operation,
         string memory inputs,
         string memory output
-    ) internal {
+    ) internal view {
         if (logOps)
             console.log(
                 string.concat(
                     LOG_PREFIX,
-                    LOG_DIVIDER,
                     padRight(operation, 16, " "),
                     LOG_DIVIDER,
                     inputs,
@@ -189,12 +188,11 @@ abstract contract MockCoFHE {
         string memory operation,
         uint256 ctHash,
         address account
-    ) internal {
+    ) internal view {
         if (logOps)
             console.log(
                 string.concat(
                     LOG_PREFIX,
-                    LOG_DIVIDER,
                     padRight(operation, 16, " "),
                     LOG_DIVIDER,
                     logCtHash(ctHash),
@@ -238,7 +236,7 @@ abstract contract MockCoFHE {
         string memory operation,
         uint256 ctHash,
         address account
-    ) public {
+    ) public view {
         logAllow(operation, ctHash, account);
     }
 


### PR DESCRIPTION
```bash
┌──────────────────┬──────────────────────────────────────────────────
│ [COFHE-MOCKS]    │ "counter.increment()" logs:
├──────────────────┴──────────────────────────────────────────────────
├ FHE.add          | euint32(4473..3424)[0] + euint32(1157..3648)[1]  =>  euint32(1106..1872)[1]
├ FHE.allowThis    | euint32(1106..1872)[1] -> 0x663f3ad617193148711d28f5334ee4ed07016602
├ FHE.allow        | euint32(1106..1872)[1] -> 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc
└─────────────────────────────────────────────────────────────────────
```

The lines that start with `├ FHE.___` are the changes. The rest is what is coming from the hh-plugin that is expected to match

```bash
hh-plugin ┌──────────────────┬──────────────────────────────────────────────────
hh-plugin │ [COFHE-MOCKS]    │ "counter.increment()" logs:
hh-plugin ├──────────────────┴──────────────────────────────────────────────────
mocks     ├ FHE.add          | euint32(4473..3424)[0] + euint32(1157..3648)[1]  =>  euint32(1106..1872)[1]
mocks     ├ FHE.allowThis    | euint32(1106..1872)[1] -> 0x663f3ad617193148711d28f5334ee4ed07016602
mocks     ├ FHE.allow        | euint32(1106..1872)[1] -> 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc
hh-plugin └─────────────────────────────────────────────────────────────────────
```