### PR TITLE
Wrap mock arithmetic in unchecked block. Fix div by 0 issue

### DIFF
--- a/contracts/MockCoFHE.sol
+++ b/contracts/MockCoFHE.sol
@@ -67,6 +67,19 @@ abstract contract MockCoFHE {
         return "unknown";
     }
 
+    function getUtypeBits(uint256 hash) internal pure returns (uint256) {
+        uint8 inputType = getUintTypeFromHash(hash);
+        if (inputType == Utils.EBOOL_TFHE) return 8;
+        if (inputType == Utils.EUINT8_TFHE) return 8;
+        if (inputType == Utils.EUINT16_TFHE) return 16;
+        if (inputType == Utils.EUINT32_TFHE) return 32;
+        if (inputType == Utils.EUINT64_TFHE) return 64;
+        if (inputType == Utils.EUINT128_TFHE) return 128;
+        if (inputType == Utils.EUINT256_TFHE) return 256;
+        if (inputType == Utils.EADDRESS_TFHE) return 160;
+        return 0;
+    }
+
     function removeFirstLetter(
         string memory str
     ) public pure returns (string memory) {
@@ -212,7 +225,10 @@ abstract contract MockCoFHE {
     }
 
     function _set(uint256 ctHash, uint256 value) internal {
-        _set(ctHash, value, false);
+        uint256 bits = getUtypeBits(ctHash);
+        uint256 mask = (1 << bits) - 1;
+
+        _set(ctHash, value & mask, false);
     }
 
     function _set(uint256 ctHash, bool value) internal {
@@ -221,7 +237,11 @@ abstract contract MockCoFHE {
 
     function _get(uint256 ctHash) internal view returns (uint256) {
         if (!inMockStorage[ctHash]) revert InputNotInMockStorage(ctHash);
-        return mockStorage[ctHash];
+
+        uint256 bits = getUtypeBits(ctHash);
+        uint256 mask = (1 << bits) - 1;
+
+        return mockStorage[ctHash] & mask;
     }
 
     // Public functions

--- a/contracts/MockCoFHE.sol
+++ b/contracts/MockCoFHE.sol
@@ -268,7 +268,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.square)) {
-            _set(ctHash, _get(input) * _get(input));
+            unchecked {
+                _set(ctHash, _get(input) * _get(input));
+            }
             logOperation(
                 "FHE.square",
                 string.concat(logCtHash(input), " * ", logCtHash(input)),
@@ -286,7 +288,9 @@ abstract contract MockCoFHE {
         uint256 input2
     ) internal {
         if (opIs(operation, FunctionId.sub)) {
-            _set(ctHash, _get(input1) - _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) - _get(input2));
+            }
             logOperation(
                 "FHE.sub",
                 string.concat(logCtHash(input1), " - ", logCtHash(input2)),
@@ -295,7 +299,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.add)) {
-            _set(ctHash, _get(input1) + _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) + _get(input2));
+            }
             logOperation(
                 "FHE.add",
                 string.concat(logCtHash(input1), " + ", logCtHash(input2)),
@@ -304,7 +310,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.xor)) {
-            _set(ctHash, _get(input1) ^ _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) ^ _get(input2));
+            }
             logOperation(
                 "FHE.xor",
                 string.concat(logCtHash(input1), " ^ ", logCtHash(input2)),
@@ -313,7 +321,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.and)) {
-            _set(ctHash, _get(input1) & _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) & _get(input2));
+            }
             logOperation(
                 "FHE.and",
                 string.concat(logCtHash(input1), " & ", logCtHash(input2)),
@@ -322,7 +332,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.or)) {
-            _set(ctHash, _get(input1) | _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) | _get(input2));
+            }
             logOperation(
                 "FHE.or",
                 string.concat(logCtHash(input1), " | ", logCtHash(input2)),
@@ -331,7 +343,14 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.div)) {
-            _set(ctHash, _get(input1) / _get(input2));
+            uint256 cleartext2 = _get(input2);
+            if (cleartext2 == 0) {
+                _set(ctHash, type(uint256).max);
+            } else {
+                unchecked {
+                    _set(ctHash, _get(input1) / cleartext2);
+                }
+            }
             logOperation(
                 "FHE.div",
                 string.concat(logCtHash(input1), " / ", logCtHash(input2)),
@@ -340,7 +359,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.rem)) {
-            _set(ctHash, _get(input1) % _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) % _get(input2));
+            }
             logOperation(
                 "FHE.rem",
                 string.concat(logCtHash(input1), " % ", logCtHash(input2)),
@@ -349,7 +370,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.mul)) {
-            _set(ctHash, _get(input1) * _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) * _get(input2));
+            }
             logOperation(
                 "FHE.mul",
                 string.concat(logCtHash(input1), " * ", logCtHash(input2)),
@@ -358,7 +381,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.shl)) {
-            _set(ctHash, _get(input1) << _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) << _get(input2));
+            }
             logOperation(
                 "FHE.shl",
                 string.concat(logCtHash(input1), " << ", logCtHash(input2)),
@@ -367,7 +392,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.shr)) {
-            _set(ctHash, _get(input1) >> _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) >> _get(input2));
+            }
             logOperation(
                 "FHE.shr",
                 string.concat(logCtHash(input1), " >> ", logCtHash(input2)),
@@ -412,9 +439,10 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.min)) {
-            uint256 min = _get(input1) < _get(input2)
-                ? _get(input1)
-                : _get(input2);
+            uint256 min;
+            unchecked {
+                min = _get(input1) < _get(input2) ? _get(input1) : _get(input2);
+            }
             _set(ctHash, min);
 
             logOperation(
@@ -431,9 +459,10 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.max)) {
-            uint256 max = _get(input1) > _get(input2)
-                ? _get(input1)
-                : _get(input2);
+            uint256 max;
+            unchecked {
+                max = _get(input1) > _get(input2) ? _get(input1) : _get(input2);
+            }
             _set(ctHash, max);
 
             logOperation(
@@ -470,7 +499,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.rol)) {
-            _set(ctHash, _get(input1) << _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) << _get(input2));
+            }
 
             logOperation(
                 "FHE.rol",
@@ -480,7 +511,9 @@ abstract contract MockCoFHE {
             return;
         }
         if (opIs(operation, FunctionId.ror)) {
-            _set(ctHash, _get(input1) >> _get(input2));
+            unchecked {
+                _set(ctHash, _get(input1) >> _get(input2));
+            }
 
             logOperation(
                 "FHE.ror",

--- a/test/TestBed.t.sol
+++ b/test/TestBed.t.sol
@@ -4,10 +4,9 @@ pragma solidity ^0.8.13;
 import {Test} from "forge-std/Test.sol";
 import {TestBed} from "../contracts/TestBed.sol";
 import {CoFheTest} from "../contracts/CoFheTest.sol";
-import {FHE, InEuint32} from "@fhenixprotocol/cofhe-contracts/FHE.sol";
+import {FHE, InEuint32, euint8} from "@fhenixprotocol/cofhe-contracts/FHE.sol";
 
 contract TestBedTest is Test, CoFheTest {
-
     TestBed private testbed;
 
     address private user = makeAddr("user");
@@ -28,5 +27,21 @@ contract TestBedTest is Test, CoFheTest {
         testbed.setNumber(number);
 
         assertHashValue(testbed.eNumber(), n);
+    }
+
+    function testOverflow() public {
+        euint8 a = FHE.asEuint8(240);
+        euint8 b = FHE.asEuint8(240);
+        euint8 c = FHE.add(a, b);
+
+        assertHashValue(euint8.unwrap(c), (240 + 240) % 256);
+    }
+
+    function testDivideByZero() public {
+        euint8 a = FHE.asEuint8(240);
+        euint8 b = FHE.asEuint8(0);
+        euint8 c = FHE.div(a, b);
+
+        assertHashValue(euint8.unwrap(c), type(uint8).max);
     }
 }


### PR DESCRIPTION
Not sure if we need to adjust the div to use the max of each utype
For example, does euint8(5) / euint8(0) = euint8(max)?

EDIT:
Now using bitmasking to ensure that overflow / underflow is handled correctly and keeps the correct uint__ size